### PR TITLE
Add grid

### DIFF
--- a/docs/layout/README.md
+++ b/docs/layout/README.md
@@ -1,0 +1,3 @@
+# Layout
+
+- [Grid](grid.md)

--- a/docs/layout/grid.md
+++ b/docs/layout/grid.md
@@ -1,12 +1,36 @@
 # Grid
 
-The grid allows components to be arranged in a consistent, orderly way. 
+The grid allows components to be arranged in a consistent, orderly way. It is based on Bulma CSS.
 
 ## Visual Examples
 
-## Best Practices
+
+### Desktop
+
+![Desktop
+Grid](https://drive.google.com/uc?id=1xa8v6mMh_flO_rJsW9D9mBpvcUuekA84)
+
+### Desktop with Sidebar
+
+![Desktop Grid with
+Sidebar](https://drive.google.com/uc?id=1FaeKR_Ojpro23JBizWrFHXHvnQaO_WPy)
+
+### Settings
+
+The grid system is flexible and responsive, which results in values that
+  change based on the viewport. Nevertheless, identifying reference values can help designers compose UIs in Sketch.
+
+| Grid Setting   | CSS Value                                                                              | Reference Value |
+|----------------|----------------------------------------------------------------------------------------|----------------:|
+| Num of columns | Varies based on columns declared                                                       |              12 |
+| Max width      | Varies based on enclosing [container](https://bulma.io/documentation/layout/container) |          1152px |
+| Column width   | Equal width within a container                                                         |        ~89.41px |
+| Column alley   | 0.75rem * 2                                                                            |            24px |
+| Column gutters | 0.75rem                                                                                |            12px |
 
 ## Resources
 
-- [Component in Abstract](https://share.goabstract.com/99ed815f-8cbe-49e2-a011-9287ef1fd7da)
-- [Bulma Grid Docs]
+- [Component in Abstract](https://share.goabstract.com/6dd3b240-8908-4c9d-8f65-fd6a53f9fd7b)
+- Bulma Docs
+  - [Columns](https://bulma.io/documentation/columns/)
+  - [Containers](https://bulma.io/documentation/layout/container/)

--- a/docs/layout/grid.md
+++ b/docs/layout/grid.md
@@ -1,0 +1,12 @@
+# Grid
+
+The grid allows components to be arranged in a consistent, orderly way. 
+
+## Visual Examples
+
+## Best Practices
+
+## Resources
+
+- [Component in Abstract](https://share.goabstract.com/99ed815f-8cbe-49e2-a011-9287ef1fd7da)
+- [Bulma Grid Docs]

--- a/docs/layout/grid.md
+++ b/docs/layout/grid.md
@@ -1,6 +1,6 @@
 # Grid
 
-The grid allows components to be arranged in a consistent, orderly way. It is based on Bulma CSS.
+The grid allows components to be arranged in a consistent, orderly way. It is based on [Bulma CSS](https://bulma.io/documentation/columns/).
 
 ## Visual Examples
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -16,7 +16,7 @@
 
 | Name | Tag | Sketch | Design Docs | Code | Code Docs |
 | --- | --- | :---: | :---: | :---: | :---: |
-| [Grid](layout/grid.md)      | - | ✅ | 🚧 | ❌ | ❌ |
+| [Grid](layout/grid.md) | - | ✅ | 🚧 | ❌ | ❌ |
 | UI Regions      | - | ✅ | ❌ | ❌ | ❌ |
 
 ## Components
@@ -35,22 +35,22 @@
 | Empty State       | - | ✅ | ❌ | ❌ | ❌ |
 | Footer            | - | ✅ | ❌ | ❌ | ❌ |
 | Guard Layout      | - | ✅ | ❌ | ❌ | ❌ |
-| [Guide Drawer](components/guide-drawer.md)      | - | ✅ | ✅ | ❌ | ❌ |
-| [Guide Trigger](components/guide-trigger.md)     | - | ✅ | ✅ | ❌ | ❌ |
+| [Guide Drawer](components/guide-drawer.md) | - | ✅ | ✅ | ❌ | ❌ |
+| [Guide Trigger](components/guide-trigger.md) | - | ✅ | ✅ | ❌ | ❌ |
 | Icon              | - | ✅ | ❌ | ❌ | ❌ |
 | Inputs            | - | ✅ | ❌ | ❌ | ❌ |
 | Lists             | - | ✅ | ❌ | ❌ | ❌ |
 | Loader            | - | ✅ | ❌ | ❌ | ❌ |
 | Modal             | - | ✅ | ❌ | ❌ | ❌ |
 | Page Title        | - | ✅ | ❌ | ❌ | ❌ |
-| [Pagination](components/pagination.md)        | - | ✅ | ✅ | ❌ | ❌ |
-| [Progress Bar](components/progress.md)      | - | ✅ | ✅ | ❌ | ❌ |
-| [Progress Column](components/progress.md)   | - | ✅ | ✅ | ❌ | ❌ |
-| [Progress Ring](components/progress.md)     | - | ✅ | ✅ | ❌ | ❌ |
+| [Pagination](components/pagination.md) | - | ✅ | ✅ | ❌ | ❌ |
+| [Progress Bar](components/progress.md) | - | ✅ | ✅ | ❌ | ❌ |
+| [Progress Column](components/progress.md) | - | ✅ | ✅ | ❌ | ❌ |
+| [Progress Ring](components/progress.md) | - | ✅ | ✅ | ❌ | ❌ |
 | Section Title     | - | ✅ | ❌ | ❌ | ❌ |
 | Sidebar           | - | ✅ | ❌ | ❌ | ❌ |
 | Table             | - | ✅ | ❌ | ❌ | ❌ |
 | Tabs              | - | ✅ | ❌ | ❌ | ❌ |
 | Tags              | - | ✅ | ❌ | ❌ | ❌ |
-| [Tooltip](components/tooltip.md)           | - | ✅ | ✅ | ❌ | ❌ |
+| [Tooltip](components/tooltip.md) | - | ✅ | ✅ | ❌ | ❌ |
 | Top Nav           | - | ✅ | ❌ | ❌ | ❌ |

--- a/docs/status.md
+++ b/docs/status.md
@@ -16,7 +16,7 @@
 
 | Name | Tag | Sketch | Design Docs | Code | Code Docs |
 | --- | --- | :---: | :---: | :---: | :---: |
-| Grid      | - | ✅ | 🚧 | ❌ | ❌ |
+| [Grid](layout/grid.md)      | - | ✅ | 🚧 | ❌ | ❌ |
 | UI Regions      | - | ✅ | ❌ | ❌ | ❌ |
 
 ## Components
@@ -35,22 +35,22 @@
 | Empty State       | - | ✅ | ❌ | ❌ | ❌ |
 | Footer            | - | ✅ | ❌ | ❌ | ❌ |
 | Guard Layout      | - | ✅ | ❌ | ❌ | ❌ |
-| Guide Drawer      | - | ✅ | ✅ | ❌ | ❌ |
-| Guide Trigger     | - | ✅ | ✅ | ❌ | ❌ |
+| [Guide Drawer](components/guide-drawer.md)      | - | ✅ | ✅ | ❌ | ❌ |
+| [Guide Trigger](components/guide-trigger.md)     | - | ✅ | ✅ | ❌ | ❌ |
 | Icon              | - | ✅ | ❌ | ❌ | ❌ |
 | Inputs            | - | ✅ | ❌ | ❌ | ❌ |
 | Lists             | - | ✅ | ❌ | ❌ | ❌ |
 | Loader            | - | ✅ | ❌ | ❌ | ❌ |
 | Modal             | - | ✅ | ❌ | ❌ | ❌ |
 | Page Title        | - | ✅ | ❌ | ❌ | ❌ |
-| Pagination        | - | ✅ | ✅ | ❌ | ❌ |
-| Progress Bar      | - | ✅ | ✅ | ❌ | ❌ |
-| Progress Column   | - | ✅ | ✅ | ❌ | ❌ |
-| Progress Ring     | - | ✅ | ✅ | ❌ | ❌ |
+| [Pagination](components/pagination.md)        | - | ✅ | ✅ | ❌ | ❌ |
+| [Progress Bar](components/progress.md)      | - | ✅ | ✅ | ❌ | ❌ |
+| [Progress Column](components/progress.md)   | - | ✅ | ✅ | ❌ | ❌ |
+| [Progress Ring](components/progress.md)     | - | ✅ | ✅ | ❌ | ❌ |
 | Section Title     | - | ✅ | ❌ | ❌ | ❌ |
 | Sidebar           | - | ✅ | ❌ | ❌ | ❌ |
 | Table             | - | ✅ | ❌ | ❌ | ❌ |
 | Tabs              | - | ✅ | ❌ | ❌ | ❌ |
 | Tags              | - | ✅ | ❌ | ❌ | ❌ |
-| Tooltip           | - | ✅ | ✅ | ❌ | ❌ |
+| [Tooltip](components/tooltip.md)           | - | ✅ | ✅ | ❌ | ❌ |
 | Top Nav           | - | ✅ | ❌ | ❌ | ❌ |

--- a/docs/status.md
+++ b/docs/status.md
@@ -4,53 +4,53 @@
 
 ## Styleguide Variables
 
-| Name | Prefix | Sketch | Design Docs | Code | Code Docs |
-| --- | --- | :---: | :---: | :---: | :---: |
-| Borders    | - | ✅ | ❌ | ❌ | ❌ |
-| Colors     | - | ✅ | ❌ | ❌ | ❌ |
-| Elevations | - | ✅ | ❌ | ❌ | ❌ |
-| Typography | - | ✅ | ❌ | ❌ | ❌ |
-| Spacing    | - | ✅ | ❌ | ❌ | ❌ |
+| Name       | Prefix | Sketch | Design Docs | Code | Code Docs |
+|------------|--------|:------:|:-----------:|:----:|:---------:|
+| Borders    | -      |   ✅    |      ❌      |  ❌   |     ❌     |
+| Colors     | -      |   ✅    |      ❌      |  ❌   |     ❌     |
+| Elevations | -      |   ✅    |      ❌      |  ❌   |     ❌     |
+| Typography | -      |   ✅    |      ❌      |  ❌   |     ❌     |
+| Spacing    | -      |   ✅    |      ❌      |  ❌   |     ❌     |
 
 ## Layout
 
-| Name | Tag | Sketch | Design Docs | Code | Code Docs |
-| --- | --- | :---: | :---: | :---: | :---: |
-| [Grid](layout/grid.md) | - | ✅ | 🚧 | ❌ | ❌ |
-| UI Regions      | - | ✅ | ❌ | ❌ | ❌ |
+| Name                   | Tag | Sketch | Design Docs | Code | Code Docs |
+|------------------------|-----|:------:|:-----------:|:----:|:---------:|
+| [Grid](layout/grid.md) | -   |   ✅    |      ✅      |  ❌   |     ❌     |
+| UI Regions             | -   |   ✅    |      ❌      |  ❌   |     ❌     |
 
 ## Components
 
-| Name | Tag | Sketch | Design Docs | Code | Code Docs |
-| --- | --- | :---: | :---: | :---: | :---: |
-| Alert Banner      | - | ✅ | ❌ | ❌ | ❌ |
-| Alert Inline      | - | ✅ | ❌ | ❌ | ❌ |
-| Alert Popup       | - | ✅ | ❌ | ❌ | ❌ |
-| Application Error | - | ✅ | ❌ | ❌ | ❌ |
-| Breadcrumb        | - | ✅ | ❌ | ❌ | ❌ |
-| Button            | - | ✅ | ❌ | ❌ | ❌ |
-| Card              | - | ✅ | ❌ | ❌ | ❌ |
-| Code Block        | - | ✅ | ❌ | ❌ | ❌ |
-| Dropdown          | - | ✅ | ❌ | ❌ | ❌ |
-| Empty State       | - | ✅ | ❌ | ❌ | ❌ |
-| Footer            | - | ✅ | ❌ | ❌ | ❌ |
-| Guard Layout      | - | ✅ | ❌ | ❌ | ❌ |
-| [Guide Drawer](components/guide-drawer.md) | - | ✅ | ✅ | ❌ | ❌ |
-| [Guide Trigger](components/guide-trigger.md) | - | ✅ | ✅ | ❌ | ❌ |
-| Icon              | - | ✅ | ❌ | ❌ | ❌ |
-| Inputs            | - | ✅ | ❌ | ❌ | ❌ |
-| Lists             | - | ✅ | ❌ | ❌ | ❌ |
-| Loader            | - | ✅ | ❌ | ❌ | ❌ |
-| Modal             | - | ✅ | ❌ | ❌ | ❌ |
-| Page Title        | - | ✅ | ❌ | ❌ | ❌ |
-| [Pagination](components/pagination.md) | - | ✅ | ✅ | ❌ | ❌ |
-| [Progress Bar](components/progress.md) | - | ✅ | ✅ | ❌ | ❌ |
-| [Progress Column](components/progress.md) | - | ✅ | ✅ | ❌ | ❌ |
-| [Progress Ring](components/progress.md) | - | ✅ | ✅ | ❌ | ❌ |
-| Section Title     | - | ✅ | ❌ | ❌ | ❌ |
-| Sidebar           | - | ✅ | ❌ | ❌ | ❌ |
-| Table             | - | ✅ | ❌ | ❌ | ❌ |
-| Tabs              | - | ✅ | ❌ | ❌ | ❌ |
-| Tags              | - | ✅ | ❌ | ❌ | ❌ |
-| [Tooltip](components/tooltip.md) | - | ✅ | ✅ | ❌ | ❌ |
-| Top Nav           | - | ✅ | ❌ | ❌ | ❌ |
+| Name                                         | Tag | Sketch | Design Docs | Code | Code Docs |
+|----------------------------------------------|-----|:------:|:-----------:|:----:|:---------:|
+| Alert Banner                                 | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Alert Inline                                 | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Alert Popup                                  | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Application Error                            | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Breadcrumb                                   | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Button                                       | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Card                                         | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Code Block                                   | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Dropdown                                     | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Empty State                                  | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Footer                                       | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Guard Layout                                 | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| [Guide Drawer](components/guide-drawer.md)   | -   |   ✅    |      ✅      |  ❌   |     ❌     |
+| [Guide Trigger](components/guide-trigger.md) | -   |   ✅    |      ✅      |  ❌   |     ❌     |
+| Icon                                         | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Inputs                                       | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Lists                                        | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Loader                                       | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Modal                                        | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Page Title                                   | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| [Pagination](components/pagination.md)       | -   |   ✅    |      ✅      |  ❌   |     ❌     |
+| [Progress Bar](components/progress.md)       | -   |   ✅    |      ✅      |  ❌   |     ❌     |
+| [Progress Column](components/progress.md)    | -   |   ✅    |      ✅      |  ❌   |     ❌     |
+| [Progress Ring](components/progress.md)      | -   |   ✅    |      ✅      |  ❌   |     ❌     |
+| Section Title                                | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Sidebar                                      | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Table                                        | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Tabs                                         | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| Tags                                         | -   |   ✅    |      ❌      |  ❌   |     ❌     |
+| [Tooltip](components/tooltip.md)             | -   |   ✅    |      ✅      |  ❌   |     ❌     |
+| Top Nav                                      | -   |   ✅    |      ❌      |  ❌   |     ❌     |

--- a/docs/status.md
+++ b/docs/status.md
@@ -12,6 +12,13 @@
 | Typography | - | ✅ | ❌ | ❌ | ❌ |
 | Spacing    | - | ✅ | ❌ | ❌ | ❌ |
 
+## Layout
+
+| Name | Tag | Sketch | Design Docs | Code | Code Docs |
+| --- | --- | :---: | :---: | :---: | :---: |
+| Grid      | - | ✅ | 🚧 | ❌ | ❌ |
+| UI Regions      | - | ✅ | ❌ | ❌ | ❌ |
+
 ## Components
 
 | Name | Tag | Sketch | Design Docs | Code | Code Docs |


### PR DESCRIPTION
Basic documentation for the grid. One thing to note: I omitted images for the mobile and tablet examples because those seemed less prescriptive. Also, the limitations on resizing images in markdown caused these to have quite a lot of visual dominance on the page. 

I also snuck in an update to the status page -- I hyperlinked the items there. 